### PR TITLE
記事作成の実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -7,7 +7,18 @@ module Api::V1
 
     def show
       article = Article.find(params[:id])
-      render json: article, each_serializer: Api::V1::ArticleSerializer
+      render json: article, serializer: Api::V1::ArticleSerializer
     end
+
+    def create
+      article = current_user.articles.create!(article_params)
+      render json: article, serializer: Api::V1::ArticleSerializer
+    end
+
+    private
+
+      def article_params
+        params.require(:article).permit(:title, :body)
+      end
   end
 end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,2 +1,5 @@
 class Api::V1::BaseApiController < ApplicationController
+  def current_user
+    @current_user ||= User.first
+  end
 end

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -1,5 +1,8 @@
 require: "rubocop-rspec"
 
+RSpec/AnyInstance:
+  Enabled: false
+
 # 日本語だと「〜の場合」になるので suffix でないと対応できない
 RSpec/ContextWording:
   Enabled: false

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -20,7 +20,7 @@
 FactoryBot.define do
   factory :article do
     title { Faker::Lorem.word }
-    body { Faker::Lorem.sentences }
+    body { Faker::Lorem.sentence }
     user
   end
 end

--- a/spec/requests/api/v1/article_request_spec.rb
+++ b/spec/requests/api/v1/article_request_spec.rb
@@ -50,4 +50,22 @@ RSpec.describe "Api::V1::Articles", type: :request do
       end
     end
   end
+
+  describe "POST /articles" do
+    subject { post(api_v1_articles_path, params: params) }
+
+    let(:params) { { article: attributes_for(:article) } }
+    let(:current_user) { create(:user) }
+    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+
+    it "記事のレコード作成ができる" do
+      aggregate_failures do
+        expect { subject }.to change { Article.where(user_id: current_user.id).count }.by(1)
+        res = JSON.parse(response.body)
+        expect(res["title"]).to eq params[:article][:title]
+        expect(res["body"]).to eq params[:article][:body]
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要
* 記事の作成機能とテストを実装

## 内容
* current_user のダミーメソッドを定義
* 記事に関する FactoryBot に誤りがあったので修正
* rubocop の判定を緩和
